### PR TITLE
Use JSON logging for production

### DIFF
--- a/util/logging.js
+++ b/util/logging.js
@@ -3,10 +3,9 @@ import winston from 'winston';
 const logger = winston.createLogger({
     level: process.env.LOG_LEVEL,
     transports: [new winston.transports.Console()],
-    format: winston.format.combine(
-        winston.format.colorize(),
-        winston.format.simple()
-    )
+    format: process.env.NODE_ENV !== 'production' ? 
+    winston.format.combine(winston.format.colorize(),winston.format.simple())
+    : winston.format.json()
 });
 
 export default logger;


### PR DESCRIPTION
This PR aims to use JSON logging for production. Current infrastructure is AWS App Runner and colors cannot be displayed correctly. Additionally, JSON logging can be further sent to pipelines for visualization and dashboarding.